### PR TITLE
Add missed bolus notification

### DIFF
--- a/diabetes-app/Services/NotificationManager.swift
+++ b/diabetes-app/Services/NotificationManager.swift
@@ -1,0 +1,43 @@
+import Foundation
+import UserNotifications
+
+class NotificationManager {
+    static let shared = NotificationManager()
+    private init() {
+        configureActions()
+    }
+
+    func requestAuthorization() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in
+            // Permission response can be handled here if needed
+        }
+    }
+
+    private func configureActions() {
+        let confirm = UNNotificationAction(identifier: "CONFIRM_ACTION",
+                                           title: "Confirm",
+                                           options: [.foreground])
+        let deny = UNNotificationAction(identifier: "DENY_ACTION",
+                                        title: "Deny",
+                                        options: [.destructive])
+        let category = UNNotificationCategory(identifier: "MISSED_BOLUS_CATEGORY",
+                                              actions: [confirm, deny],
+                                              intentIdentifiers: [],
+                                              options: [])
+        UNUserNotificationCenter.current().setNotificationCategories([category])
+    }
+
+    func scheduleMissedBolusNotification() {
+        let content = UNMutableNotificationContent()
+        content.title = "Possible Missed Meal Bolus"
+        content.body = "Have you taken your bolus for the recent meal?"
+        content.sound = .default
+        content.categoryIdentifier = "MISSED_BOLUS_CATEGORY"
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let request = UNNotificationRequest(identifier: UUID().uuidString,
+                                            content: content,
+                                            trigger: trigger)
+        UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+    }
+}

--- a/diabetes-app/Views/SettingsView.swift
+++ b/diabetes-app/Views/SettingsView.swift
@@ -9,7 +9,13 @@ import SwiftUI
 
 struct SettingsView: View {
     var body: some View {
-        Text("Settings Screen")
+        VStack {
+            Text("Settings Screen")
+            Button("Test Missed Bolus Notification") {
+                NotificationManager.shared.scheduleMissedBolusNotification()
+            }
+            .padding()
+        }
     }
 }
 

--- a/diabetes-app/diabetes_appApp.swift
+++ b/diabetes-app/diabetes_appApp.swift
@@ -7,8 +7,14 @@
 
 import SwiftUI
 
+// Notification support
+import UserNotifications
+
 @main
 struct diabetes_appApp: App {
+    init() {
+        NotificationManager.shared.requestAuthorization()
+    }
     var body: some Scene {
         WindowGroup {
             ContentView()


### PR DESCRIPTION
## Summary
- add `NotificationManager` service
- request notification authorization when app launches
- add test notification button in Settings

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68844e3b5d38832bac91a3a8fe659f9a