### PR TITLE
Add nightly meal reminder notification

### DIFF
--- a/diabetes-app/NotificationManager.swift
+++ b/diabetes-app/NotificationManager.swift
@@ -1,0 +1,40 @@
+import Foundation
+import UserNotifications
+
+class NotificationManager {
+    static let shared = NotificationManager()
+    private init() {}
+
+    func requestAuthorization() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, error in
+            if let error = error {
+                print("Notification permission error: \(error.localizedDescription)")
+            } else if granted {
+                self.scheduleNightlyReminder()
+            }
+        }
+    }
+
+    func scheduleNightlyReminder() {
+        let center = UNUserNotificationCenter.current()
+        center.removePendingNotificationRequests(withIdentifiers: ["nightlyReminder"])
+
+        var components = DateComponents()
+        components.hour = 20
+        components.minute = 0
+
+        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: true)
+
+        let content = UNMutableNotificationContent()
+        content.title = "Update Today's Meals"
+        content.body = "Please log any meals you missed recording today."
+        content.sound = .default
+
+        let request = UNNotificationRequest(identifier: "nightlyReminder", content: content, trigger: trigger)
+        center.add(request) { error in
+            if let error = error {
+                print("Error scheduling nightly reminder: \(error)")
+            }
+        }
+    }
+}

--- a/diabetes-app/diabetes_appApp.swift
+++ b/diabetes-app/diabetes_appApp.swift
@@ -9,6 +9,9 @@ import SwiftUI
 
 @main
 struct diabetes_appApp: App {
+    init() {
+        NotificationManager.shared.requestAuthorization()
+    }
     var body: some Scene {
         WindowGroup {
             ContentView()


### PR DESCRIPTION
## Summary
- add `NotificationManager` to handle local notifications
- schedule a nightly reminder at 8pm for missed meal events
- request notification permission during app launch

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68845267b96c832b9b6c115946833e06