### PR TITLE
Add skeleton CGM widget

### DIFF
--- a/diabetes-app/Models/BolusEvent.swift
+++ b/diabetes-app/Models/BolusEvent.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct BolusEvent: Identifiable {
+    let id = UUID()
+    let timestamp: Date
+    let reason: String
+}

--- a/diabetes-app/ViewModels/BolusLogger.swift
+++ b/diabetes-app/ViewModels/BolusLogger.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+class BolusLogger: ObservableObject {
+    @Published var events: [BolusEvent] = []
+
+    func logMissedMeal() {
+        let event = BolusEvent(timestamp: Date(), reason: "Missed meal bolus")
+        events.append(event)
+        // TODO: Persist event to storage
+        print("Logged missed meal bolus: \(event)")
+    }
+}

--- a/diabetes-app/Widgets/CGMWidget.swift
+++ b/diabetes-app/Widgets/CGMWidget.swift
@@ -1,0 +1,60 @@
+import WidgetKit
+import SwiftUI
+
+struct CGMEntry: TimelineEntry {
+    let date: Date
+    let value: Int
+}
+
+struct CGMProvider: TimelineProvider {
+    func placeholder(in context: Context) -> CGMEntry {
+        CGMEntry(date: Date(), value: 110)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (CGMEntry) -> Void) {
+        let entry = CGMEntry(date: Date(), value: 110)
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<CGMEntry>) -> Void) {
+        let entry = CGMEntry(date: Date(), value: Int.random(in: 80...180))
+        let timeline = Timeline(entries: [entry], policy: .after(Date().addingTimeInterval(300)))
+        completion(timeline)
+    }
+}
+
+struct CGMWidgetEntryView: View {
+    var entry: CGMProvider.Entry
+    @ObservedObject var logger = BolusLogger()
+
+    var body: some View {
+        VStack {
+            Text("\(entry.value) mg/dL")
+                .font(.headline)
+            Button("Log Missed Bolus") {
+                logger.logMissedMeal()
+            }
+            .buttonStyle(.borderedProminent)
+            .font(.caption)
+        }
+    }
+}
+
+struct CGMWidget: Widget {
+    let kind: String = "CGMWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: CGMProvider()) { entry in
+            CGMWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("CGM Quick Log")
+        .description("View glucose and log a missed meal bolus.")
+        .supportedFamilies([.systemSmall])
+    }
+}
+
+#Preview(as: .systemSmall) {
+    CGMWidget()
+} timeline: {
+    CGMEntry(date: .now, value: 123)
+}


### PR DESCRIPTION
## Summary
- create new `BolusEvent` model
- add `BolusLogger` to record missed meal bolus events
- implement `CGMWidget` for quick CGM display and logging

## Testing
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884cb377a1c832ba3db9a572b9046c3